### PR TITLE
Simp

### DIFF
--- a/table/smyh_simp.txt
+++ b/table/smyh_simp.txt
@@ -9,7 +9,7 @@
 不	i1
 是	j1
 了	k1
-就	l1
+好	l1
 现	m1
 里	n1
 中	o1
@@ -36,13 +36,16 @@
 回	do1
 讲	dy1
 便	ef1
-使	ef2
+条	ef2
+速	fo2
 赛	hs1
 题	jf1
 类	kt1
-好	lk1
 品	oo1
 知	qo1
 途	rf1
 散	sh1
 爱	vp1
+降	ze1
+仁	ey1
+灯	ma1

--- a/table/smyh_simp.txt
+++ b/table/smyh_simp.txt
@@ -37,7 +37,8 @@
 讲	dy1
 便	ef1
 条	ef2
-速	fo2
+速	fo1
+逼	fo2
 赛	hs1
 题	jf1
 类	kt1


### PR DESCRIPTION
增加若干的二級簡碼：

ef2 改爲「条」，使得「条休」分離。
fo1 fo2增加「速逼」，使得「速逼逗」分離。
增加「降仁灯」二簡。

L的一簡設爲「好」，這樣一來，就不用設置 LK 二簡了，因爲「就」 的三碼同碼無高頻字。

以上設置後，前1500常用字中，重碼字只剩下了：
「堂尘」
「货倾」